### PR TITLE
separate amd64 and 386 archs, use powershell in 386

### DIFF
--- a/lib/pkg/perfcounters/objects.go
+++ b/lib/pkg/perfcounters/objects.go
@@ -1,0 +1,6 @@
+package perfcounters
+
+type PerformanceCounter struct {
+	Name  string
+	Value float64
+}

--- a/lib/pkg/perfcounters/perfcounters_386.go
+++ b/lib/pkg/perfcounters/perfcounters_386.go
@@ -1,0 +1,72 @@
+package perfcounters
+
+// +build windows,386
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+type PowerShell struct {
+	powerShell string
+}
+
+func New() *PowerShell {
+	ps, _ := exec.LookPath("powershell.exe")
+	return &PowerShell{
+		powerShell: ps,
+	}
+}
+
+func (p *PowerShell) Execute(args ...string) (stdOut string, stdErr string, err error) {
+	args = append([]string{"-NoProfile", "-NonInteractive"}, args...)
+	cmd := exec.Command(p.powerShell, args...)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	stdOut, stdErr = stdout.String(), stderr.String()
+	return
+}
+
+// ReadPerformanceCounter reads a performance counter
+func ReadPerformanceCounter(counter string, pollingAttempts int, pollingDelay int) (PerformanceCounter, error) {
+	// in amd64 the pdh.dll usage isn't playing nice. We're going to use powershell directly and text parsing
+	var perfcounter PerformanceCounter
+
+	perfcounter.Name = counter
+	perfcounter.Value = 0
+
+	var command string
+	command = fmt.Sprintf("Write-Output (Get-Counter -Counter \"%s\" -SampleInterval %d -MaxSamples %d |\n", counter, pollingDelay, pollingAttempts) +
+		"Select-Object -ExpandProperty CounterSamples |\n" +
+		"Select-Object -ExpandProperty CookedValue |\n" +
+		"Measure-Object -Average).Average"
+	glog.Infof("Generated powershell performance monitor command:\n%s\n", command)
+	posh := New()
+	stdout, _, err := posh.Execute(command)
+	glog.Infof("powershell output: \n\n %v", stdout)
+	if err != nil {
+		glog.Errorf("Error running powershell script to retrieve performance counter values: %v", err)
+		return perfcounter, err
+	}
+	trimmed_stdout := strings.TrimSpace(stdout)
+	avgValue, err := strconv.ParseFloat(trimmed_stdout, 64)
+	if err != nil {
+		glog.Errorf("Could not parse %s to float64: %v", stdout, err)
+		return perfcounter, err
+	}
+
+	perfcounter.Value = avgValue
+
+	return perfcounter, nil
+
+}

--- a/lib/pkg/perfcounters/perfcounters_amd64.go
+++ b/lib/pkg/perfcounters/perfcounters_amd64.go
@@ -1,6 +1,6 @@
 package perfcounters
 
-// +build windows
+// +build windows,amd64
 
 import (
 	"errors"
@@ -8,13 +8,9 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/golang/glog"
 	"github.com/lxn/win"
 )
-
-type PerformanceCounter struct {
-	Name  string
-	Value float64
-}
 
 // ReadPerformanceCounter reads a performance counter
 func ReadPerformanceCounter(counter string, pollingAttempts int, pollingDelay int) (PerformanceCounter, error) {
@@ -49,7 +45,6 @@ func ReadPerformanceCounter(counter string, pollingAttempts int, pollingDelay in
 		for index := 0; index < samples; index++ {
 			ret = win.PdhCollectQueryData(queryHandle)
 			if ret == win.ERROR_SUCCESS {
-
 				var bufSize uint32
 				var bufCount uint32
 				var size uint32 = uint32(unsafe.Sizeof(win.PDH_FMT_COUNTERVALUE_ITEM_DOUBLE{}))
@@ -62,7 +57,9 @@ func ReadPerformanceCounter(counter string, pollingAttempts int, pollingDelay in
 					if ret == win.ERROR_SUCCESS {
 						for i := 0; i < int(bufCount); i++ {
 							c := filledBuf[i]
-							data = append(data, c.FmtValue.DoubleValue)
+							formattedValue := c.FmtValue.DoubleValue
+							glog.Infof("data point retrieved: [%s] %v", counter, formattedValue)
+							data = append(data, formattedValue)
 						}
 					}
 				}


### PR DESCRIPTION
resolves #12 by separating 386 and amd64, uses powershell in 386 target instead of the lxn/win library