### PR TITLE
Prevent glog log files

### DIFF
--- a/cmd/check_available_memory/main.go
+++ b/cmd/check_available_memory/main.go
@@ -5,5 +5,7 @@ import (
 )
 
 func main() {
+	nagiosfoundation.InitializeCommand()
+
 	nagiosfoundation.CheckAvailableMemory()
 }

--- a/cmd/check_performance_counter/main.go
+++ b/cmd/check_performance_counter/main.go
@@ -6,5 +6,7 @@ import (
 )
 
 func main() {
+	nagiosfoundation.InitializeCommand()
+
 	nagiosfoundation.CheckPerformanceCounter()
 }

--- a/lib/app/nagiosfoundation/init_cmd.go
+++ b/lib/app/nagiosfoundation/init_cmd.go
@@ -1,0 +1,48 @@
+package nagiosfoundation
+
+import (
+	"flag"
+)
+
+// SetFlagIfNotProvided sets a command line flag if it wasn't
+// provided. This overcomes a command line flag in library
+// being set to a different default value than desired.
+//
+// Returns true if the command line flag was not provided
+// and therefore was set to the value provided.
+func SetFlagIfNotProvided(flagName string, flagValue string) bool {
+	flagSet := false
+	flag.Parse()
+
+	flag.Visit(func(f *flag.Flag) {
+		if (*f).Name == flagName {
+			flagSet = true
+		}
+	})
+
+	if !flagSet {
+		flag.Set(flagName, flagValue)
+	}
+
+	return !flagSet
+}
+
+// SetDefaultGlogStderr will prevent the glog package from
+// defaulting to creating new log files on every execution,
+// set the logtostderr option for glog to true if it wasn't
+// specified on the command line.
+func SetDefaultGlogStderr() {
+	SetFlagIfNotProvided("logtostderr", "true")
+}
+
+// InitializeCommand executes all the functions to
+// initialize/setup/configure a command check in the
+// nagiosfoundation package. The exported functions can
+// be called independently if needed, but calling
+// InitializeCommand() will call all of them for you.
+//
+// This is being done in anticipation of also emitting a
+// version on request.
+func InitializeCommand() {
+	SetDefaultGlogStderr()
+}

--- a/lib/app/nagiosfoundation/init_cmd_test.go
+++ b/lib/app/nagiosfoundation/init_cmd_test.go
@@ -1,0 +1,44 @@
+package nagiosfoundation
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestSetFlagIfNotProvided(t *testing.T) {
+	// Save args and flagset for restoration
+	savedArgs := os.Args
+	savedFlagCommandLine := flag.CommandLine
+
+	// Reset the default flag set
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	pgmName := "TestSetFlagIfNotProvided"
+	flagName := "testflagname"
+	flagDefault := "defaultValue"
+	flagOverride := "overrideValue"
+	flagNotProvided := "notProvidedValue"
+	flagPtr := flag.String(flagName, flagDefault, "flag for testing")
+
+	// Flag not provided on the command line therefore it is
+	// set internally.
+	os.Args = []string{pgmName}
+	SetFlagIfNotProvided(flagName, flagNotProvided)
+	flag.Parse()
+	if *flagPtr != flagNotProvided {
+		t.Error("Flag not provided and was not set")
+	}
+
+	// Flag provided on the command line therefore do not
+	// set it internally.
+	os.Args = []string{pgmName, "-" + flagName, flagOverride}
+	SetFlagIfNotProvided(flagName, flagNotProvided)
+	flag.Parse()
+	if *flagPtr != flagOverride {
+		t.Error("Flag was provided but was also set")
+	}
+
+	os.Args = savedArgs
+	flag.CommandLine = savedFlagCommandLine
+}


### PR DESCRIPTION
Fix #33 

Implements a generic way to override command line defaults from a library then a specific call to override glog's logging to files in the `tmp` directory and instead output to `stderr` while allow for a user to also override the setting especially for troubleshooting and debugging.

Started a new source file meant to eventually contain other setup routines such as displaying a version if desired.