### PR TITLE
Constrain check_performance_counter to Windows builds only

### DIFF
--- a/cmd/check_performance_counter/main.go
+++ b/cmd/check_performance_counter/main.go
@@ -1,4 +1,5 @@
 // +build windows
+
 package main
 
 import (


### PR DESCRIPTION
Fix #38 