### PR TITLE
Add test targets to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 bin
 vendor
 _vendor*
+coverage.*

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ clean:
 	./godelw clean
 	rm -rf $(package_path)
 
+test:
+	go test -v ./...
+
+test-godel:
+	./godelw test
+
+coverage:
+	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go tool cover -html=coverage.txt -o coverage.html
+
 release: clean package
 	ghr $(version) $(package_path)
 


### PR DESCRIPTION
`test`, `test-godel`, and `coverage` have been added to implement #45.
