### PR TITLE
Add PR validation via travis-ci and codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+go:
+  - 1.11.5
+
+# Only clone the most recent commit.
+git:
+  depth: 1
+
+install:
+  - test ! -d /home/travis/gopath/src/github.com/jkerry && mv /home/travis/gopath/src/github.com/* /home/travis/gopath/src/github.com/jkerry
+  - mv /home/travis/gopath/src/github.com/jkerry/nagios-foundation /home/travis/gopath/src/github.com/jkerry/nagiosfoundation
+  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - dep ensure -v
+
+script:
+  - go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && bash <(curl -s https://codecov.io/bash)
+  - make package

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# godel_version is only used to ensure all the godel bits
+# have been downloaded before determining the project-version.
+godel_version := $(shell ./godelw version)
 version := $(shell ./godelw project-version)
 package_path = ./out/package
 package_version = $(package_path)/$(version)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # nagios-foundation
 
-A suite of Nagios style checks and metrics covering the basic needs for monitoring in a Sensu-like system.
+[![Build Status](https://travis-ci.com/jkerry/nagios-foundation.svg?branch=master)](https://travis-ci.com/jkerry/nagios-foundation)
+[![codecov](https://codecov.io/gh/jkerry/nagios-foundation/branch/master/graph/badge.svg)](https://codecov.io/gh/jkerry/nagios-foundation)
 
+A suite of Nagios style checks and metrics covering the basic needs for monitoring in a Sensu-like system.
 ---
 
 ## Building


### PR DESCRIPTION
All tests are not operational but there are enough (`check_service`, `check_user_group`, `init_cmd` and the upcoming `check_process`) that this is useful already.

This PR adds support for using [Travis CI](https://travis-ci.com) for unit tests and to verify builds. It also adds [Codecov](https://codecov.io) support for reviewing test coverage.

Note that once this PR is merged, the owner (@jkerry) must create Github linked accounts on both of the above and link in this project. Once that's done, the Collaborators should be able to handle any remaining configuration.

This addresses Issue #4 