### PR TITLE
Resolve merge bug in check_user_group

### DIFF
--- a/cmd/check_user_group/main.go
+++ b/cmd/check_user_group/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	nagiosfoundation.CheckUserGroupFlags()
+	nagiosfoundation.CheckUserGroupFlagsWithExit()
 }


### PR DESCRIPTION
Previous mass PR merge somehow missed a function call rename with `check_user_group`. This PR resolves that and should get builds going again.