### PR TITLE
fix badge link to Travis CI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nagios-foundation
 
-[![Build Status](https://travis-ci.org/jkerry/nagios-foundation.svg?branch=master)](https://travis-ci.com/jkerry/nagios-foundation)
+[![Build Status](https://travis-ci.org/jkerry/nagios-foundation.svg?branch=master)](https://travis-ci.org/jkerry/nagios-foundation)
 [![codecov](https://codecov.io/gh/jkerry/nagios-foundation/branch/master/graph/badge.svg)](https://codecov.io/gh/jkerry/nagios-foundation)
 
 A suite of Nagios style checks and metrics covering the basic needs for monitoring in a Sensu-like system.


### PR DESCRIPTION
Link is to `travis-ci.com`, change to valid `travis-ci.org`